### PR TITLE
prevent erroneous array in `ppf` with _scalar_if_array_all_equal

### DIFF
--- a/betapert/funcs.py
+++ b/betapert/funcs.py
@@ -84,7 +84,7 @@ _ppf_fallbacks = {
 
 
 def _scalar_if_array_all_equal(array: np.ndarray | float) -> np.float64 | np.ndarray | float:
-    if isinstance(array, np.ndarray) and np.all(array == array[0]):
+    if isinstance(array, np.ndarray) and array.size != 0 and np.all(array == array[0]):
         return array[0]
     return array
 
@@ -113,10 +113,9 @@ def _calc_alpha_beta(
     if DEBUG and any(isinstance(x, np.ndarray) for x in (mini, mode, maxi, lambd)):
         sys.stderr.write("CAB: unexpected arrays in method parameters\n")
     if isinstance(alpha, np.ndarray) and isinstance(beta, np.ndarray):
-        if np.all(alpha == alpha[0]) and np.all(beta == beta[0]):
-            return _scalar_if_array_all_equal(alpha), _scalar_if_array_all_equal(beta)
         if DEBUG:
             sys.stderr.write(f"CAB: Unexpected arrays: alpha={alpha}, beta={beta}\n")
+        return _scalar_if_array_all_equal(alpha), _scalar_if_array_all_equal(beta)
     return alpha, beta
 
 

--- a/betapert/funcs.py
+++ b/betapert/funcs.py
@@ -83,12 +83,18 @@ _ppf_fallbacks = {
 }
 
 
+def _scalar_if_array_all_equal(array: np.ndarray | float) -> np.float64 | np.ndarray | float:
+    if isinstance(array, np.ndarray) and np.all(array == array[0]):
+        return array[0]
+    return array
+
+
 def _calc_alpha_beta(
     mini: np.float64 | np.ndarray | float,
     mode: np.float64 | np.ndarray | float,
     maxi: np.float64 | np.ndarray | float,
     lambd: np.float64 | np.ndarray | float,
-) -> tuple[np.float64 | np.ndarray | float | int, np.float64 | np.ndarray | float | int]:
+) -> tuple[np.float64 | np.ndarray | float, np.float64 | np.ndarray | float]:
     """Calculate alpha and beta parameters for the underlying beta distribution.
 
     Args:
@@ -108,7 +114,7 @@ def _calc_alpha_beta(
         sys.stderr.write("CAB: unexpected arrays in method parameters\n")
     if isinstance(alpha, np.ndarray) and isinstance(beta, np.ndarray):
         if np.all(alpha == alpha[0]) and np.all(beta == beta[0]):
-            return alpha[0], beta[0]
+            return _scalar_if_array_all_equal(alpha), _scalar_if_array_all_equal(beta)
         if DEBUG:
             sys.stderr.write(f"CAB: Unexpected arrays: alpha={alpha}, beta={beta}\n")
     return alpha, beta
@@ -130,6 +136,11 @@ def sf(x, mini, mode, maxi, lambd=4):
 
 
 def ppf(q, mini, mode, maxi, lambd=4, *, fallback=None):
+    mini = _scalar_if_array_all_equal(mini)
+    mode = _scalar_if_array_all_equal(mode)
+    maxi = _scalar_if_array_all_equal(maxi)
+    lambd = _scalar_if_array_all_equal(lambd)
+
     alpha, beta = _calc_alpha_beta(mini, mode, maxi, lambd)
     _beta_ppf = mini + (maxi - mini) * scipy.stats.beta.ppf(q, alpha, beta)
     # Use fallback if any values are NaN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "beta-pert-dist-scipy"
-version = "0.2.0"
+version = "0.2.1"
 homepage = "https://github.com/hbmartin/betapert"
 description = "Top-level package for beta-PERT distribution."
 authors = ["Tom Adamczewski <tadamczewskipublic@gmail.com>", "Harold Martin harold.martin@gmail.com"]


### PR DESCRIPTION
## Summary by Sourcery

Add helper to collapse uniform numpy arrays to scalar values and apply it to sanitize inputs and outputs in the percent-point function and alpha–beta calculation, preventing spurious array results. Bump package version to 0.2.1.

Bug Fixes:
- Prevent ppf from emitting erroneous numpy arrays by collapsing uniform arrays to scalars.

Enhancements:
- Introduce _scalar_if_array_all_equal to convert uniform numpy arrays into scalar values.
- Apply array-to-scalar collapse in ppf parameters and in _calc_alpha_beta outputs to ensure consistent scalar results.

Build:
- Bump package version from 0.2.0 to 0.2.1 in pyproject.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of inputs that are arrays with identical values, now automatically simplified to scalars for more intuitive results.

* **Chores**
  * Updated the application version to 0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add helper to convert uniform arrays to scalars in `ppf` and `_calc_alpha_beta`, updating package to 0.2.1.
> 
>   - **Behavior**:
>     - Add `_scalar_if_array_all_equal` to convert uniform numpy arrays to scalars in `funcs.py`.
>     - Apply `_scalar_if_array_all_equal` in `ppf()` and `_calc_alpha_beta()` to ensure scalar outputs.
>   - **Build**:
>     - Update package version from 0.2.0 to 0.2.1 in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hbmartin%2Fbetapert&utm_source=github&utm_medium=referral)<sup> for f670932e183aab80650613c9d36fed38442f7a17. You can [customize](https://app.ellipsis.dev/hbmartin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->